### PR TITLE
添加StickyFooter

### DIFF
--- a/source/css/_base/public.styl
+++ b/source/css/_base/public.styl
@@ -23,6 +23,12 @@ body
   font-size font-size
   color color-font
   line-height line-height
+  min-height: 100vh
+  display: -webkit-flex
+  display: flex
+  -webkit-flex-direction: column
+  flex-direction: column
+  
 
 iframe
   margin-top 10px

--- a/source/css/_partial/index.styl
+++ b/source/css/_partial/index.styl
@@ -1,5 +1,7 @@
 /*! index layout */
 #container
+  -webkit-flex: 1
+  flex: 1
   width 95%
   margin 0 auto
   overflow hidden


### PR DESCRIPTION
有时会因为页面上`#container`高度不够导致footer离开页面底部
![错误示例图片](http://7xn38i.com1.z0.glb.clouddn.com/2015-11-08%2013%3A10%3A28屏幕截图.png)