### PR TITLE
解决首页加载时disqus出现“Cannot read property 'appendChild' of null”的问题

### DIFF
--- a/layout/_partial/after_footer.ejs
+++ b/layout/_partial/after_footer.ejs
@@ -132,7 +132,7 @@ $(document).ready(function(){
 </script>
 <% } %>
 
-<% if (theme.duoshuo_shortname){ %>
+<% if (theme.duoshuo_shortname && page.comments){ %>
 <script type="text/javascript">
   var duoshuoQuery = {short_name:"<%= theme.duoshuo_shortname %>"};
   (function() {
@@ -145,7 +145,7 @@ $(document).ready(function(){
   })();
 </script> 
 <% } %>
-<% if( (config.disqus_shortname || theme.disqus_shortname)) { %>
+<% if( (config.disqus_shortname || theme.disqus_shortname) && page.comments) { %>
 <script type="text/javascript">
 <% if(config.disqus_shortname){ %>
 var disqus_shortname = '<%= config.disqus_shortname %>';


### PR DESCRIPTION
after_footer.ejs 判断逻辑
```
<% if( (config.disqus_shortname || theme.disqus_shortname)) { %>
```
comment.ejs 判断逻辑
```
<% if( (config.disqus_shortname || theme.disqus_shortname) && page.comments) { %>
```

启用 disqus 评论框, 首页 console 会出现 Cannot read property 'appendChild' of null
因为加载首页时，判断逻辑加载了 disqus 的 js , 而没有加载 disqus 对应的`<div id="disqus_thread"></div>`

将after_footer.ejs 判断逻辑加上 ` && page.comments` 即可解决。
```
<% if( (config.disqus_shortname || theme.disqus_shortname) && page.comments) { %>
```


参考: [“Cannot read property 'appendChild' of null” with Disqus on Backbone website](http://stackoverflow.com/questions/30575237/cannot-read-property-appendchild-of-null-with-disqus-on-backbone-website)