### PR TITLE
Add: GitHub Ribbons

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -96,3 +96,4 @@
   </body>
  </html>
 <% } %>
+<a href="https://github.com/you"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>


### PR DESCRIPTION
在博客右上角添加Github的Fork Me图标。

TODO：
Github的跳转URL，需要更改为配置中的github的url。

参考：
1. [5. 优化Hexo 5.1 添加“Fork me on Github” ribbon](http://www.cnblogs.com/zhcncn/p/4097881.html)
1. [GitHub Ribbons](https://github.com/blog/273-github-ribbons)
